### PR TITLE
[어드민] 컨트롤러 뷰 반환 시 항상 request 객체 포함시키기

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
@@ -19,9 +19,7 @@ public class AdminAccountController {
     private final AdminAccountService adminAccountService;
 
     @GetMapping("/admin/members")
-    public String members(HttpServletRequest request, Model model) {
-        model.addAttribute("request", request);
-
+    public String members() {
         return "admin/members";
     }
 

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
@@ -1,13 +1,10 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.dto.response.AdminAccountResponse;
-import com.fastcampus.projectboardadmin.dto.response.UserAccountResponse;
 import com.fastcampus.projectboardadmin.service.AdminAccountService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
@@ -16,8 +16,7 @@ public class ArticleCommentManagementController {
     private final ArticleCommentManagementService articleCommentManagementService;
 
     @GetMapping
-    public String articleComments(HttpServletRequest request, Model model) {
-        model.addAttribute("request", request);
+    public String articleComments(Model model) {
         model.addAttribute(
                 "comments",
                 articleCommentManagementService.getArticleComments().stream().map(ArticleCommentResponse::of).toList()

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
@@ -2,7 +2,6 @@ package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.dto.response.ArticleCommentResponse;
 import com.fastcampus.projectboardadmin.service.ArticleCommentManagementService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
@@ -16,8 +16,7 @@ public class ArticleManagementController {
     private final ArticleManagementService articleManagementService;
 
     @GetMapping
-    public String articles(HttpServletRequest request, Model model) {
-        model.addAttribute("request", request);
+    public String articles(Model model) {
         model.addAttribute(
                 "articles",
                 articleManagementService.getArticles().stream().map(ArticleResponse::withoutContent).toList()

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
@@ -2,7 +2,6 @@ package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.dto.response.ArticleResponse;
 import com.fastcampus.projectboardadmin.service.ArticleManagementService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/GlobalControllerAdvice.java
@@ -1,0 +1,16 @@
+package com.fastcampus.projectboardadmin.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class GlobalControllerAdvice {
+
+    @ModelAttribute
+    public void addHttpServletRequestToModel(Model model, HttpServletRequest request) {
+        model.addAttribute("request", request);
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
@@ -2,7 +2,6 @@ package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.dto.response.UserAccountResponse;
 import com.fastcampus.projectboardadmin.service.UserAccountManagementService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
@@ -16,8 +16,7 @@ public class UserAccountManagementController {
     private final UserAccountManagementService userAccountManagementService;
 
     @GetMapping
-    public String userAccounts(HttpServletRequest request, Model model) {
-        model.addAttribute("request", request);
+    public String userAccounts(Model model) {
         model.addAttribute(
                 "userAccounts",
                 userAccountManagementService.getUserAccounts().stream().map(UserAccountResponse::from).toList()


### PR DESCRIPTION
이 pr은 HttpServletRequest 객체를 항상 뷰의 `model`에 포함 시키도록 구현한다.

This closes #55 